### PR TITLE
fix!: compatible with multiQC v1.22 which removed utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ git push origin master
 # This example add picard metrics PF_READS_ALIGNED
 # all fields used by multiqc, for example title, can be set
 multiqc_cgs:
-  Picard:
-    PF_READS_ALIGNED:
-      title: "M Aligned reads"
-      description: "Number of million reads in bam from Picard"
-      format: "{:.1f}"
-      shared_key: "read_count"
+  "Picard: HsMetrics":
+    ZERO_CVG_TARGETS_PCT:
+      title: "Target bases with zero coverage [%]"
+      description: "Target bases with zero coverage [%] from Picard"
+      min: 0
+      max: 100
+      scale: "RdYlGn-rev"
+      format: "{:.2%}"
 
 ``

--- a/README.md
+++ b/README.md
@@ -21,4 +21,7 @@ multiqc_cgs:
       scale: "RdYlGn-rev"
       format: "{:.2%}"
 
-``
+```
+
+## Compatibility
+For multiqc_cgs v1.0.0 and later, [MultiQC](https://seqera.io/multiqc/) >v1.21 is needed.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ git push origin master
 
 ```
 # Add the following entry to your multiqc config
-# This example add picard metrics PF_READS_ALIGNED
+# This example add picard hsmetrics ZERO_CVG_TARGETS_PCT
 # all fields used by multiqc, for example title, can be set
 multiqc_cgs:
   "Picard: HsMetrics":

--- a/multiqc_cgs/__init__.py
+++ b/multiqc_cgs/__init__.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from pkg_resources import get_distribution
-from multiqc.utils import config
+from multiqc import config
 
 __version__ = get_distribution("multiqc_cgs").version
 config.multiqc_cgs_version = __version__

--- a/multiqc_cgs/hooks.py
+++ b/multiqc_cgs/hooks.py
@@ -3,7 +3,7 @@
 core here to add in extra functionality. """
 
 import logging
-from multiqc.utils import report, config
+from multiqc import report, config
 from collections import OrderedDict
 
 log = logging.getLogger('multiqc')


### PR DESCRIPTION
With the release of [MultiQC v1.22](https://github.com/MultiQC/MultiQC/blob/v1.22/CHANGELOG.md) `multiqc.utils.config` and `multiqc.utils.report` moved to `multiqc.config` and `multiqc.report` ([pull request](https://github.com/MultiQC/MultiQC/pull/2542)) which caused multiqc_cgs not to trigger when running multiqc.